### PR TITLE
fix validation

### DIFF
--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -1483,6 +1483,10 @@ impl Global {
                     continue;
                 }
                 unsafe {
+                    cmd_buf_raw.transition_buffers(iter::once(hal::BufferBarrier::<A> {
+                        buffer: tlas.instance_buffer.read().as_ref().unwrap(),
+                        usage: hal::BufferUses::MAP_READ..hal::BufferUses::COPY_DST,
+                    }));
                     let temp = hal::BufferCopy {
                         src_offset: range.start as u64,
                         dst_offset: 0,


### PR DESCRIPTION
**Connections**
fixes validation messages from vulkan by transitioning the tlas instance buffer

**Description**
adds a extra line to tlas instance transition buffer, fixes validation errors about WRITE_AFTER_WRITE

**Testing**
tested with ray cube compute 
before:
log filled with
````cmd
        Validation Error: [ SYNC-HAZARD-WRITE-AFTER-WRITE ] Object 0: handle = 0x21887baf5f0, type = VK_OBJECT_TYPE_QUEUE; | MessageID = 0x5c0ec5d6 | vkQueueSubmit():  Hazard WRITE_AFTER_WRITE for entry 1, VkCommandBuffer 0x2189
45073d0[], Submitted access info (submitted_usage: SYNC_COPY_TRANSFER_WRITE, command: vkCmdCopyBuffer, seq_no: 3, reset_no: 1). Access info (prior_usage: SYNC_COPY_TRANSFER_WRITE, write_barriers: SYNC_VERTEX_SHADER_ACCELERATION_
STRUCTURE_READ|SYNC_FRAGMENT_SHADER_ACCELERATION_STRUCTURE_READ|SYNC_COMPUTE_SHADER_ACCELERATION_STRUCTURE_READ|SYNC_ACCELERATION_STRUCTURE_BUILD_ACCELERATION_STRUCTURE_READ|SYNC_ACCELERATION_STRUCTURE_BUILD_ACCELERATION_STRUCTURE_WRITE, queue: VkQueue 0x21887baf5f0[], submit: 1, batch: 0, batch_tag: 27, command: vkCmdCopyBuffer, command_buffer: VkCommandBuffer 0x218944ec2b0[], seq_no: 3, reset_no: 3).
[2024-04-26T05:46:16Z ERROR wgpu_hal::vulkan::instance]         objects: (type: QUEUE, hndl: 0x21887baf5f0, name: ?)
[2024-04-26T05:46:16Z ERROR wgpu_hal::vulkan::instance] VALIDATION [SYNC-HAZARD-WRITE-AFTER-WRITE (0x5c0ec5d6)]
````

after:
````cmd
[2024-04-26T06:25:53Z INFO  wgpu_examples::framework] Surface resize PhysicalSize { width: 1424, height: 714 }
[2024-04-26T06:25:53Z INFO  wgpu_examples::framework] Surface resize PhysicalSize { width: 800, height: 600 }
[2024-04-26T06:25:53Z INFO  wgpu_examples::framework] Surface resize PhysicalSize { width: 800, height: 600 }
[2024-04-26T06:25:54Z INFO  wgpu_examples::framework] Frame time 9.49ms (105.4 FPS)
[2024-04-26T06:25:55Z INFO  wgpu_examples::framework] Frame time 8.33ms (120.0 FPS)
[2024-04-26T06:25:56Z INFO  wgpu_examples::framework] Frame time 8.33ms (120.0 FPS)
[2024-04-26T06:25:57Z INFO  wgpu_examples::framework] Frame time 8.33ms (120.0 FPS)
[2024-04-26T06:25:58Z INFO  wgpu_examples::framework] Frame time 8.33ms (120.0 FPS)
[2024-04-26T06:25:59Z INFO  wgpu_examples::framework] Frame time 8.33ms (120.0 FPS)
[2024-04-26T06:26:00Z INFO  wgpu_examples::framework] Frame time 8.33ms (120.0 FPS)
[2024-04-26T06:26:01Z INFO  wgpu_examples::framework] Frame time 8.33ms (120.0 FPS)
````

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - `--target wasm32-unknown-unknown` done by github actions
  - `--target wasm32-unknown-emscripten`  done by github actions
- Run `cargo xtask test` to run tests. done by github actions
- Add change to `CHANGELOG.md`. Part of the ray-tracing PR